### PR TITLE
Avoid incomplete name display when using some fonts

### DIFF
--- a/Drawing.cs
+++ b/Drawing.cs
@@ -80,6 +80,9 @@ namespace Sunglasses
                 var infl = size * 25;
                 var hght = size * 2f;
                 var nicknames = Settings.DisplayNicknames;
+                graphics.TextRenderingHint = TextRenderingHint.AntiAlias;
+                var sf = GH_TextRenderingConstants.CenterCenter;
+                sf.FormatFlags |= StringFormatFlags.NoClip;
                 graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
 
                 foreach (IGH_DocumentObject obj in objects)
@@ -96,7 +99,7 @@ namespace Sunglasses
                     GH_PaletteStyle style = GH_CapsuleRenderEngine.GetImpliedStyle(palette, obj.Attributes);
                     using (Brush brh = new SolidBrush(Color.FromArgb(alpha, style.Edge)))
                     {
-                        graphics.DrawString(nicknames ? obj.NickName : obj.Name, Settings.Font, brh, box, Grasshopper.GUI.GH_TextRenderingConstants.CenterCenter);
+                        graphics.DrawString(nicknames ? obj.NickName : obj.Name, Settings.Font, brh, box, sf);
                     }
 
                 }


### PR DESCRIPTION
Avoid incomplete name display when using some fonts。
![Snipaste_2021-01-31_03-11-28](https://user-images.githubusercontent.com/15703508/106365826-01f2a480-6373-11eb-9f01-c2b37c67828a.png)
![Snipaste_2021-01-31_03-17-37](https://user-images.githubusercontent.com/15703508/106365828-03bc6800-6373-11eb-841c-3f12be08161e.png)

