### PR TITLE
Abstract build process slightly to enable macOS Visual Studio builds

### DIFF
--- a/Sunglasses.csproj
+++ b/Sunglasses.csproj
@@ -11,6 +11,9 @@
     <RootNamespace>Sunglasses</RootNamespace>
     <AssemblyName>Sunglasses</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RhinoPluginType>gha</RhinoPluginType><!-- Tells MacOS VS to rename to gha -->
+    <TargetExt>.gha</TargetExt><!-- Tells Windows VS to rename to gha -->
+    <RhinoMacLauncher>/Applications/Rhino 7.app</RhinoMacLauncher><!-- Enable Debug for macOS Visual Studio -->
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <NuGetPackageImportStamp>
@@ -36,12 +39,15 @@
   <ItemGroup>
     <Reference Include="GH_IO, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=6a29997d2e6b4f97, processorArchitecture=MSIL">
       <HintPath>packages\Grasshopper.6.0.18016.23451\lib\net45\GH_IO.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Grasshopper, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=dda4f5ec2cd80803, processorArchitecture=MSIL">
       <HintPath>packages\Grasshopper.6.0.18016.23451\lib\net45\Grasshopper.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="RhinoCommon, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
       <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\RhinoCommon.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -83,9 +89,10 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <PropertyGroup>
-    <PostBuildEvent>copy  /Y "$(TargetDir)$(ProjectName).dll" "$(TargetDir)$(ProjectName).gha"
-copy  /Y "$(TargetDir)$(ProjectName).dll" "$(USERPROFILE)\AppData\Roaming\Grasshopper\Libraries\$(ProjectName).gha"</PostBuildEvent>
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(Windows))">
+    <PostBuildEvent>
+      copy  /Y "$(TargetDir)$(ProjectName).gha" "$(USERPROFILE)\AppData\Roaming\Grasshopper\Libraries\$(ProjectName).gha"
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>


### PR DESCRIPTION
Hey, thanks for making Sunglassess and thanks for making it open source! I teach/demo Grasshopper a fair bit and find the labels to be super helpful.

I was hoping to track down a bug I noticed and submit a PR to fix it. In setting up a local copy/build of Sunglasses, I thought it might be useful to upstream a couple of quick changes:

1. In the `.csproj` I add a few fields that handle the `dll` > `gha` renaming across both macOS and Windows without the need to do a shell script style rename (which is tricky to maintain between two platforms). I'm not sure exactly when this changed in the McNeel starter template, but I haven't had any problems in the versions of Visual Studio I run across either platform.
2. As the `PostBuildEvent` now only handles copying to `USERPROFILE` I made that run only on Windows environs as a macOS build will throw trying to run `copy` in its terminal
3. I set the standard Grasshopper/RhinoCommon dependencies to not copy to `bin` as I don't think there is any need for them to be there, and it breaks the (common?) practice of using `GrasshopperDeveloperSettings` to reference the GHA from the build output directly.